### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 春节期间学习react native的第一个demo，基于es6语法，仿拉勾，目前暂时只支持ios，后期会再做一个Android版本
 
-###依赖组件
+### 依赖组件
   	"dependencies": {
     	"react-native": "^0.19.0",
     	"react-native-swiper": "^1.4.3",
@@ -14,6 +14,6 @@
 react-native-vector-icons有点特殊，里面要导入一个依赖工程，要看一下官网https://github.com/oblador/react-native-vector-icons
 
 
-###效果图
+### 效果图
 
 ![img](https://github.com/heruijun/react-native-lagou/blob/master/pic.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
